### PR TITLE
fix(android): un-reverse setLauncherVisible

### DIFF
--- a/android/src/main/java/com/reactnativeintercom/IntercomModule.kt
+++ b/android/src/main/java/com/reactnativeintercom/IntercomModule.kt
@@ -55,9 +55,9 @@ class RNNIntercomModule(reactContext: ReactApplicationContext) : ReactContextBas
     @ReactMethod
     fun setLauncherVisible(visible: Boolean, promise: Promise) {
       if (visible)
-        Intercom.client().setLauncherVisibility(Intercom.Visibility.GONE)
-      else
         Intercom.client().setLauncherVisibility(Intercom.Visibility.VISIBLE)
+      else
+        Intercom.client().setLauncherVisibility(Intercom.Visibility.GONE)
       promise.resolve(null)
     }
 


### PR DESCRIPTION
Argument is used the wrong way round on Android - need to call `Intercom.setLauncherVisible(true)` to hide the launcher.