### PR TITLE
(fix)iOS: Fix typo in setInAppMessagesVisible declaration

### DIFF
--- a/ios/Intercom.m
+++ b/ios/Intercom.m
@@ -22,7 +22,7 @@ RCT_EXTERN_METHOD(presentMessageComposer:(nullable NSString *)initialMessage res
 
 RCT_EXTERN_METHOD(presentHelpCenter: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(setInAppMessagesVisible: (Bool)visible resolver: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(setInAppMessagesVisible: (BOOL)visible resolver: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getUnreadConversationCount: (RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock)reject)
 


### PR DESCRIPTION
I tried to call `Intercom.setInAppMessgesVisible(false)` in my React Native app. I got this error.

<img width="426" alt="Screen Shot 2021-04-16 at 11 48 15 AM" src="https://user-images.githubusercontent.com/200488/115062425-54def100-9eb8-11eb-8585-9714ddee8f6d.png">

This PR seems to fix it. The error goes away and the call succeeds.